### PR TITLE
adding note about limited random access for collections API

### DIFF
--- a/api.rst
+++ b/api.rst
@@ -110,6 +110,8 @@ A random sample of results can be fetched by setting the ``start`` parameter to 
 keyword ``random``. The ``count`` parameter specifies the size of the sample. This
 is limited to up to 20 results and does not work across multiple jobs.
 
+.. note:: :ref:`collections-api` currently does not support getting specific items
+   with ``index`` parameter nor random sampling using ``start=random``
 
 .. _metapar:
 


### PR DESCRIPTION
Hi!

Adding a note about limited random access options for collections API because the docs currently imply it supports random access just like the other APIs (it ignores `index` and does not support `start=random`).