### PR TITLE
dash.rst: fix Scrapy CloseSpider extension link

### DIFF
--- a/dash.rst
+++ b/dash.rst
@@ -188,4 +188,4 @@ This covers the basics of the dashboard, but there is much more. Feel free to pl
 .. _`knowledge base`: http://support.scrapinghub.com/forum/24895-knowledge-base/
 .. _`support forum`: http://support.scrapinghub.com/
 .. _`Memory Usage Extension`: http://doc.scrapy.org/en/latest/topics/extensions.html#module-scrapy.contrib.memusage
-.. _`Scrapy CloseSpider extension`: http://doc.scrapy.org/en/latest/topics/exceptions.html#closespider
+.. _`Scrapy CloseSpider extension`: http://doc.scrapy.org/en/latest/topics/extensions.html#module-scrapy.contrib.closespider


### PR DESCRIPTION
It lead to CloseSpider *exception* previously.