### PR TITLE
Show shub usage in the page, add syncshub Makefile target to update it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ help:
 	@echo "  changes   to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck to check all external links for integrity"
 	@echo "  doctest   to run all doctests embedded in the documentation (if enabled)"
+	@echo "  syncshub  to update shub usage according to locally installed shub"
 
 clean:
 	-rm -rf $(BUILDDIR)/*
@@ -85,6 +86,16 @@ linkcheck:
 
 htmlview: html
 	python -c "import webbrowser; webbrowser.open('_build/html/index.html')"
+
+syncshub: TMPFILE:=$(shell mktemp)
+syncshub:
+	@echo "Checking if shub is installed (install with: pip install shub)"
+	shub --help >/dev/null
+	@echo "Updating shub.rst ..."
+	awk '/BEGIN_SHUB_USAGE/ { print; skip=1; next; }; /END_SHUB_USAGE/ { skip=0; system("echo ::; echo; echo \"    $$ shub --help\"; shub --help | sed \"s/^/    /\"")}; !skip {print}' shub.rst > $(TMPFILE)
+	cat $(TMPFILE) > shub.rst
+	rm -f $(TMPFILE)
+	@echo "Done"
 
 doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest

--- a/shub.rst
+++ b/shub.rst
@@ -18,7 +18,7 @@ Usage
 
 Here are the available commands:
 
-.. BEGIN_SHUB_USAGE
+.. BEGIN_SHUB_USAGE - DO NOT EDIT MANUALLY THIS BLOCK
 ::
 
     $ shub --help

--- a/shub.rst
+++ b/shub.rst
@@ -16,9 +16,30 @@ To install ``shub`` use::
 Usage
 =====
 
-To see available commands just type::
+Here are the available commands:
 
-    shub
+.. BEGIN_SHUB_USAGE
+::
+
+    $ shub --help
+    Usage: shub [OPTIONS] COMMAND [ARGS]...
+    
+      Scrapinghub command-line client
+    
+    Options:
+      --help  Show this message and exit.
+    
+    Commands:
+      deploy       Deploy Scrapy project to Scrapy Cloud
+      deploy-egg   Build and deploy egg from source
+      deploy-reqs  Build and deploy eggs from requirements.txt
+      fetch-eggs   Download a project's eggs from the Scrapy...
+      login        add Scrapinghug API key into the netrc file
+.. END_SHUB_USAGE
+
+To see the usage for each command, use::
+
+    shub <COMMAND> --help
 
 Configuration
 =============

--- a/shub.rst
+++ b/shub.rst
@@ -35,6 +35,8 @@ Here are the available commands:
       deploy-reqs  Build and deploy eggs from requirements.txt
       fetch-eggs   Download a project's eggs from the Scrapy...
       login        add Scrapinghug API key into the netrc file
+      logout       remove Scrapinghug API key from the netrc...
+      version      Show shub version
 .. END_SHUB_USAGE
 
 To see the usage for each command, use::


### PR DESCRIPTION
Hey folks,

The motivation for this PR is to enable an user to know the features available in shub: http://doc.scrapinghub.com/shub.html
Today, an user has to install the tool to find out what it can do.

The goal was also to have minimal friction to update it, so the usage information is obtained through `make syncshub`, which will just use the output of `shub --help` -- this way anyone with the latest version of shub installed locally can update it without much hassle.

Does this look good?

Note: Let's wait for the shub's release before merging this (should happen next week).