### PR TITLE
Add note on pre-emptive authentication to Crawlera documentation

### DIFF
--- a/_static/crawlera-httpc.java
+++ b/_static/crawlera-httpc.java
@@ -1,10 +1,14 @@
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -23,6 +27,14 @@ public class ClientProxyAuthentication {
             HttpHost target = new HttpHost("twitter.com", 443, "http");
             HttpHost proxy = new HttpHost("paygo.crawlera.com", 8010);
 
+            AuthCache authCache = new BasicAuthCache();
+
+            BasicScheme basicAuth = new BasicScheme();
+            authCache.put(target, basicAuth);
+
+            HttpClientContext ctx = HttpClientContext.create();
+            ctx.setAuthCache(authCache);
+
             RequestConfig config = RequestConfig.custom()
                 .setProxy(proxy)
                 .build();
@@ -33,7 +45,7 @@ public class ClientProxyAuthentication {
             System.out.println("Executing request " + httpget.getRequestLine() + 
                 " to " + target + " via " + proxy);
 
-            CloseableHttpResponse response = httpclient.execute(target, httpget);
+            CloseableHttpResponse response = httpclient.execute(target, httpget, ctx);
             try {
                 System.out.println("----------------------------------------");
                 System.out.println(response.getStatusLine());
@@ -47,4 +59,5 @@ public class ClientProxyAuthentication {
             httpclient.close();
         }
     }
+
 }

--- a/_static/crawlera-proxy.cs
+++ b/_static/crawlera-proxy.cs
@@ -11,9 +11,10 @@ namespace ProxyRequest
             var myProxy = new WebProxy("http://paygo.crawlera.com:8010");
             myProxy.Credentials = new NetworkCredential("<API KEY>", "");
 
-            WebRequest request = WebRequest.Create("http://twitter.com");
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create("http://twitter.com");
             request.Headers["X-Crawlera-Use-HTTPS"] = "1";
             request.Proxy = myProxy;
+            request.PreAuthenticate = true;
 
             WebResponse response = request.GetResponse();
             Console.WriteLine("Response Status: " 

--- a/crawlera.rst
+++ b/crawlera.rst
@@ -378,6 +378,10 @@ For password safety reasons this content is displayed as ``(hidden)`` in the Pol
 Basic Examples in Various Programming Languages
 ================================================
 
+.. warning::
+
+    Some HTTP client libraries including Apache HttpClient and .NET don't send authentication headers by default. This can result in doubled requests so pre-emptive authentication should be enabled where this is the case.
+
 In the following examples we'll be making HTTPS requests to https://twitter.com through Crawlera. Note that HTTPS transfer is enabled by :ref:`x-crawlera-use-https` header. For this reason, indicating ``https://`` in URLs is not required.
 
 Python


### PR DESCRIPTION
Added note on pre-emptive authentication to example section of Crawlera doc. Also updated .NET and Java code examples.

@qrilka can you review? Thanks.