### PR TITLE
Crawlera documentation corrections

### DIFF
--- a/crawlera.rst
+++ b/crawlera.rst
@@ -172,7 +172,7 @@ Issue the endpoint :ref:`/sessions` with the ``GET`` method to list your session
 
 *Example*::
 
-    curl -U <API key>: paygo.crawlera.com:8010/sessions
+    curl -u <API key>: paygo.crawlera.com:8010/sessions
     {"1836172": "<SLAVE1>", "1691272": "<SLAVE2>"}
 
 .. _/sessions/SESSION_ID:

--- a/crawlera.rst
+++ b/crawlera.rst
@@ -184,7 +184,7 @@ Issue the endpoint :ref:`/sessions/SESSION_ID` with the ``DELETE`` method in ord
 
 *Example*::
 
-    curl -U <API key>: paygo.crawlera.com:8010/sessions/1836172 -X DELETE
+    curl -u <API key>: paygo.crawlera.com:8010/sessions/1836172 -X DELETE
 
 Request Limits
 --------------

--- a/crawlera.rst
+++ b/crawlera.rst
@@ -257,7 +257,7 @@ This header instructs Crawlera to use sessions which will tie requests to a part
 
     X-Crawlera-Session: create
 
-When ``create`` value is passed, Crawlera creates a new session an ID of which will be returned in the response header with the same name. All subsequent requests should use that returned session ID to prevent random slave switching between requests. Crawlera sessions currently have maximum lifetime of 1 hour and each user is limited to a maximum of 10 concurrent sessions.
+When ``create`` value is passed, Crawlera creates a new session an ID of which will be returned in the response header with the same name. All subsequent requests should use that returned session ID to prevent random slave switching between requests. Crawlera sessions currently have maximum lifetime of 30 minutes and each user is limited to a maximum of 100 concurrent sessions.
 
 .. _x-crawlera-use-https:
 

--- a/crawlera.rst
+++ b/crawlera.rst
@@ -136,6 +136,8 @@ bad_header             540            Bad header value for *<some_header>*
 
 \* Crawlera limits the number of concurrent connections to 500 for standard users, and 5000 for enterprise users.
 
+.. _sessions-request-limits:
+
 Sessions and Request Limits 
 ===========================
 
@@ -257,7 +259,7 @@ This header instructs Crawlera to use sessions which will tie requests to a part
 
     X-Crawlera-Session: create
 
-When ``create`` value is passed, Crawlera creates a new session an ID of which will be returned in the response header with the same name. All subsequent requests should use that returned session ID to prevent random slave switching between requests. Crawlera sessions currently have maximum lifetime of 30 minutes and each user is limited to a maximum of 100 concurrent sessions.
+When ``create`` value is passed, Crawlera creates a new session an ID of which will be returned in the response header with the same name. All subsequent requests should use that returned session ID to prevent random slave switching between requests. Crawlera sessions currently have maximum lifetime of 30 minutes. See :ref:`sessions-request-limits` for information on the maximum number of sessions.
 
 .. _x-crawlera-use-https:
 


### PR DESCRIPTION
Per @serhiy-yasko 's request I've corrected some errors in the Crawlera documentation:

1. Crawlera list sessions and delete sessions documentation described using curl's `-U` switch for authentication. This is incorrect as it instructs curl to use the authentication details with the proxy. This has been corrected to use the `-u` switch which instead provides authentication to the server.
2. Session lifetime was described as 1 hour. This has been corrected to 30 minutes. (https://github.com/scrapinghub/crawlera/blob/develop/src/pm_sessions.erl#L23)
3. Maximum number of sessions was described as 10. This has been corrected to 100. (https://github.com/scrapinghub/crawlera/blob/develop/src/pm_sessions.erl#L25)

@qrilka can you please confirm before I merge? Thanks.