### PR TITLE
Fixed Java Crawlera example

### DIFF
--- a/_static/crawlera-httpc.java
+++ b/_static/crawlera-httpc.java
@@ -1,3 +1,4 @@
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -12,6 +13,7 @@ import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
 
 public class ClientProxyAuthentication {
@@ -30,7 +32,10 @@ public class ClientProxyAuthentication {
             AuthCache authCache = new BasicAuthCache();
 
             BasicScheme basicAuth = new BasicScheme();
-            authCache.put(target, basicAuth);
+            basicAuth.processChallenge(
+                    new BasicHeader(HttpHeaders.PROXY_AUTHENTICATE,
+                                    "Basic realm=\"Crawlera\""));
+            authCache.put(proxy, basicAuth);
 
             HttpClientContext ctx = HttpClientContext.create();
             ctx.setAuthCache(authCache);

--- a/crawlera.rst
+++ b/crawlera.rst
@@ -382,7 +382,7 @@ Basic Examples in Various Programming Languages
 
 .. warning::
 
-    Some HTTP client libraries including Apache HttpClient and .NET don't send authentication headers by default. This can result in doubled requests so pre-emptive authentication should be enabled where this is the case.
+    Some HTTP client libraries including Apache HttpComponents Client and .NET don't send authentication headers by default. This can result in doubled requests so pre-emptive authentication should be enabled where this is the case.
 
 In the following examples we'll be making HTTPS requests to https://twitter.com through Crawlera. Note that HTTPS transfer is enabled by :ref:`x-crawlera-use-https` header. For this reason, indicating ``https://`` in URLs is not required.
 
@@ -425,6 +425,8 @@ Making use of `request <https://github.com/request/request>`_, an HTTP client:
 
 Java
 ----
+
+.. note:: Because of `HTTPCLIENT-1649 <https://issues.apache.org/jira/browse/HTTPCLIENT-1649>`_ you should use version 4.5 of HttpComponents Client or later.
 
 Quoting from an example published at `The Apache HttpComponents™ <http://hc.apache.org/httpcomponents-client-ga/examples.html>`_ project website and inserting Crawlera details:
 


### PR DESCRIPTION
Basic scheme should be applied to proxy not target website and https://issues.apache.org/jira/browse/HTTPCLIENT-1599 requires extra step to set it up for proxies.