### PR TITLE
Remove paygo warning for X-Crawlera-Session

### DIFF
--- a/crawlera.rst
+++ b/crawlera.rst
@@ -251,8 +251,6 @@ X-Crawlera-Session
     
     An experimental beta feature.
 
-:sub:`Not available on Pay-as-You-Go plan.`
-
 This header instructs Crawlera to use sessions which will tie requests to a particular slave until it gets banned.
 
 *Example*::


### PR DESCRIPTION
It was enabled for ordinary Crawlera users in Crawlera 1.4.2, see https://github.com/scrapinghub/crawlera/pull/477