### PR TITLE
Added info on Crawlera cookie tracking

### DIFF
--- a/crawlera.rst
+++ b/crawlera.rst
@@ -67,6 +67,13 @@ SSL certificate verification in your HTTP client.
 
 The Crawlera Certificate authority can be downloaded here: :download:`crawlera-ca.crt`
 
+.. _working-with-cookies:
+
+Working with Cookies
+--------------------
+
+Crawlera manages cookies for you by default and retains them for up to 15 minutes since the last request. If you want to store and manage cookies yourself, you should disable Crawlera cookie tracking via the :ref:`x-crawlera-cookies` header to avoid potential conflicts.
+
 .. _upgrading-your-account:
 
 Upgrading Your Account
@@ -222,6 +229,8 @@ This header instructs Crawlera not to check responses against its ban rules and 
 *Example*::
 
     X-Crawlera-No-Bancheck: 1
+
+.. _x-crawlera-cookies:
 
 X-Crawlera-Cookies
 -------------------

--- a/crawlera.rst
+++ b/crawlera.rst
@@ -72,7 +72,9 @@ The Crawlera Certificate authority can be downloaded here: :download:`crawlera-c
 Working with Cookies
 --------------------
 
-Crawlera manages cookies for you by default and retains them for up to 15 minutes since the last request. If you want to store and manage cookies yourself, you should disable Crawlera cookie tracking via the :ref:`x-crawlera-cookies` header to avoid potential conflicts.
+Crawlera manages cookies for you by default and retains them for up to 15 minutes since the last request. Crawlera stores cookies per proxy, and as a result consecutive requests will almost always have different cookies, so if you need to use cookies for things like authentication then you will want to manage them yourself.
+
+If you want to store and manage cookies yourself you will need to disable Crawlera cookie tracking via the :ref:`x-crawlera-cookies` header. If cookie tracking isn't disabled then Crawlera will discard the cookies and send its own instead.
 
 .. _upgrading-your-account:
 


### PR DESCRIPTION
Added a brief section on using cookies with Crawlera, explaining that Crawlera cookie tracking should be disabled if managing cookies in your spider, and mentioning the retention of 15 minutes.

@pawelmhm / @qrilka can you please review? Thanks.