### PR TITLE
[Scrapy Cloud/Dash] Add desccription of `cancel_timeout` outcome

### DIFF
--- a/dash.rst
+++ b/dash.rst
@@ -99,6 +99,7 @@ Outcome                      Meaning
 `no_reason`_                 the job finished OK but didn't set an outcome
 `failed`_                    the job failed to start
 `cancelled`_                 the job was cancelled from Scrapinghub Dashboard or API
+`cancel_timeout`_            the job failed to shutdown gracefully after cancellation
 `shutdown`_                  the job was cancelled from Scrapy code
 `memusage_exceeded`_         the job was cancelled due to high memory usage
 `banned`_                    the job was cancelled because target site banned the spider
@@ -135,6 +136,12 @@ cancelled
 The job was cancelled from :ref:`the dashboard <dash>`, the :ref:`API <api>` or
 by the system if it got inactive and failed to produce anything (not even log
 entries) for an hour.
+
+cancel_timeout
+--------------
+
+The job has failed to shutdown gracefully after cancellation (taking more than
+5 minutes).
 
 shutdown
 --------


### PR DESCRIPTION
Dash UI says this in the pop-over:

> The job was cancelled because either it has failed to shutdown gracefully after cancellation (taking more than 5 minutes) or it hasn’t been producing anything (not even log entries) for an hour

but I think the latter reason gets "cancelled" as outcome.