### PR TITLE
Add python-hubstorage examples

### DIFF
--- a/api/client_library.rst
+++ b/api/client_library.rst
@@ -1,0 +1,6 @@
+**Client Library**
+
+Most of the features provided by the API are also available through the python-hubstorage_ client library, as you can see below in :ref:`items-examples`. You have to authenticate yourself to create a ``HubstorageClient`` object to interact with hubstorage::
+
+    >>> from hubstorage import HubstorageClient
+    >>> hc = HubstorageClient(auth=APIKEY)

--- a/api/frontier.rst
+++ b/api/frontier.rst
@@ -77,8 +77,6 @@ HTTP::
 
 Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
 
-    >>> from hubstorage import HubstorageClient
-    >>> hc = HubstorageClient(auth=APIKEY)
     >>> frontier = hc.get_project('78').frontier
     >>> frontier.add('test', 'example.com', [{'fp': '/some/path.html'}])
     >>> frontier.flush()

--- a/api/items.rst
+++ b/api/items.rst
@@ -6,6 +6,12 @@ Items API
 
 .. note:: Even though these APIs support writing, they are most often used for reading. The crawlers running on Scrapinghub cloud are the ones that write to these endpoints. However, both operations are documented here for completion.
 
+The Items API lets you interact with the items stored in the hubstorage backend for your projects. For example, you can download all the items for the job ``'53/34/7'`` through::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7
+
+.. include:: client_library.rst
+
 Item object
 -----------
 
@@ -45,33 +51,113 @@ GET    Retrieve items for a given project, spider, or job. format, meta, nodata
 POST   Insert items for a given job                        N/A
 ====== =================================================== ====================
 
-GET examples::
+.. _items-examples:
 
-    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7/fieldname                     # Retrieve value of a single field
-    ...
-    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7/0                             # Retrieve first item of a job
-    ...
-    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7                               # Retrieve all items for a job
-    ...
-    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34                                 # Retrieve all jobs for a spider
-    ...
-    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/                                   # Retrieve all jobs for a project
-    ...
-    $ curl -u APIKEY: "https://storage.scrapinghub.com/items/53/1/7?meta=_key&nodata=1"           # Use nodata parameter to show only specified meta key
+Examples
+^^^^^^^^
+
+**Retrieve all items from a given job**
+
+HTTP::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7
+
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
+
+    >>> items = hc.get_job('53/34/7').items.list()
+
+**Retrive first item from a given job**
+
+HTTP::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7/0
+
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
+
+    >>> item = hc.get_job('53/34/7').items.get(0)
+
+
+**Retrieve values from a single field**
+
+HTTP::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7/fieldname
+
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
+
+    >>> items_fieldname = [item['fieldname'] for item in hc.get_job('53/34/7').items.list()]
+
+
+**Retrieve all items from a given spider**
+
+HTTP::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34
+
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
+
+    >>> for job in hc.get_project(53).jobq.list(spider='spidername'):
+    >>>     for item in hc.get_job(job['key']).items.list():
+                print item
+
+
+**Retrieve all items from a given project**
+
+HTTP::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/
+
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
+
+    >>> items = hc.get_project(53).items.list()
+
+
+**Get meta field from items**
+
+To get only metadata from items, pass the ``nodata=1`` parameter along with the meta field that you want to get.
+
+HTTP::
+
+    $ curl -u APIKEY: "https://storage.scrapinghub.com/items/53/1/7?meta=_key&nodata=1"
     {"_key":"53/1/7/0"}
     {"_key":"53/1/7/1"}
     {"_key":"53/1/7/2"}
-    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7 -H "Accept: application/json" # Retrieve items for a job in JSON format
-    {"_key":"1111111/1/1/0"}
 
-POST examples::
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
 
-    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7 -X POST -T items.jl                                  # Add items to a job
-    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7 -X POST -T items.jl -H "content-range: items 500-/*" # Use the Content-Range header to specify a start index
+    >>> items = hc.get_job('53/1/7').items.iter_values(meta='_key', nodata='1')
 
-Where ``items.jl`` is a file containing the items in JSON lines format.
+
+**Get items in a specific format**
+
+Check the available formats in the :ref:`api-overview-resultformats` section at the API Overview.
+
+JSON::
+
+    $ curl -u APIKEY: "https://storage.scrapinghub.com/items/53/34/7?meta=_key&nodata=1 -H \"Accept: application/json\""
+    [{"_key":"28144/1/1/0"},{"_key":"28144/1/1/1"},{"_key":"28144/1/1/2"}, ...]
+
+JSON Lines::
+
+    $ curl -u APIKEY: "https://storage.scrapinghub.com/items/53/34/7?meta=_key&nodata=1 -H \"Accept: application/x-jsonlines\""
+    {"_key":"28144/1/1/0"}
+    {"_key":"28144/1/1/1"}
+    {"_key":"28144/1/1/2"}
+    ...
+
+
+**Add items to a job via POST**
+
+Add the items stored in the file ``items.jl`` (JSON lines format) to the job ``53/34/7``::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7 -X POST -T items.jl
+
+Use the ``Content-Range`` header to specify a start index::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7 -X POST -T items.jl -H "content-range: items 500-/*"
 
 The API will only return ``200`` if the data was successfully stored. There's no limit on the amount of data you can send, but a ``HTTP 413`` response will be returned if any single item is over 1M.
+
 
 items/:project_id/:spider_id/:job_id/stats
 ------------------------------------------
@@ -98,7 +184,20 @@ Method Description                                Supported parameters
 GET    Retrieve item stats for the specified job. all
 ====== ========================================== ====================
 
-Example::
+
+Example
+^^^^^^^
+
+**Get the stats from a given job**
+
+HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7/stats
     {"counts":{"field1":9350,"field2":514},"totals":{"input_bytes":14390294,"input_values":10000}}
+
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
+
+    >>> print hc.get_job('53/34/7').items.stats()
+
+
+.. _`python-hubstorage`: http://github.com/scrapinghub/python-hubstorage

--- a/api/jobq.rst
+++ b/api/jobq.rst
@@ -4,7 +4,9 @@
 JobQ API
 ========
 
-You can use the JobQ API to retrieve finished jobs from the queue.
+The JobQ API allows you to retrieve finished jobs from the queue.
+
+.. include:: client_library.rst
 
 jobq/:project_id/list
 ---------------------
@@ -17,13 +19,13 @@ Field Description
 ts    The time at which the job was added to the queue.
 ===== =================================================
 
-========= ============================================= ========
-Parameter Description                                   Required
-========= ============================================= ========
-startts   UNIX timestamp at which to begin results.     No
-endts     UNIX timestamp at which to end results.       No
-stop      The job key at which to stop showing results. No
-========= ============================================= ========
+========= ========================================================= ========
+Parameter Description                                               Required
+========= ========================================================= ========
+startts   UNIX timestamp at which to begin results, in millisecons. No
+endts     UNIX timestamp at which to end results, in millisecons.   No
+stop      The job key at which to stop showing results.             No
+========= ========================================================= ========
 
 ====== ==================================== ====================
 Method Description                          Supported parameters
@@ -31,22 +33,56 @@ Method Description                          Supported parameters
 GET    List jobs for the specified project. startts, endts, stop
 ====== ==================================== ====================
 
-GET examples::
+Examples
+^^^^^^^^
 
-    $ curl -u APIKEY: https://storage.scrapinghub.com/jobq/53/list # Return jobs for a given project
+**List jobs for a given project**
+
+HTTP::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/jobq/53/list
     {"key":"53/7/81","ts":1397762393489}
     {"key":"53/7/80","ts":1395111612849}
     {"key":"53/7/78","ts":1393972804722}
     {"key":"53/7/77","ts":1393972734215}
-    $ curl -u APIKEY: "https://storage.scrapinghub.com/jobq/53/list?startts=1359774955431&endts=1359774955440" # Return jobs finished between two timestamps
+
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
+
+    >>> from hubstorage import HubstorageClient
+    >>> hc = HubstorageClient(auth=APIKEY)
+    >>> jobs = hc.get_project('53').jobq.list()
+
+
+**List jobs finished between two timestamps**
+
+If you pass the ``startts`` and ``endts`` parameters, the API will return only the jobs finished between them.
+
+HTTP::
+
+    $ curl -u APIKEY: "https://storage.scrapinghub.com/jobq/53/list?startts=1359774955431&endts=1359774955440"
     {"key":"53/6/7","ts":1359774955439}
     {"key":"53/3/3","ts":1359774955437}
     {"key":"53/9/1","ts":1359774955431}
 
-JobQ returns the list of jobs with the most recently finished first.
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
 
-We recommend associating the key of the most recently finished job with the downloaded data. When you want to update your data later on, you can list the jobs and stop at the previously downloaded job::
+    >>> jobs = hc.get_project('53').jobq.list(startts=1359774955431, endts=1359774955440)
 
-    $ curl -u APIKEY: "https://storage.scrapinghub.com/jobq/53/list?stop=53/7/81" # Retrieve all jobs that have finished since the specified job
+
+
+**Retrieve jobs finished after some job**
+
+JobQ returns the list of jobs, with the most recently finished first. We recommend associating the key of the most recently finished job with the downloaded data. When you want to update your data later on, you can list the jobs and stop at the previously downloaded job, through the ``stop`` parameter::
+
+HTTP::
+
+    $ curl -u APIKEY: "https://storage.scrapinghub.com/jobq/53/list?stop=53/7/81"
     {"key":"53/7/83","ts":1403610146780}
     {"key":"53/7/82","ts":1397827910849}
+
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
+
+    >>> jobs = hc.get_project('53').jobq.list(stop='53/7/81')
+
+
+.. _`python-hubstorage`: http://github.com/scrapinghub/python-hubstorage

--- a/api/overview.rst
+++ b/api/overview.rst
@@ -43,10 +43,11 @@ dash.scrapinghub.com
 ---------------------
 
 .. toctree::
+   :maxdepth: 2
 
-	comments
-	eggs
-	jobs
+   comments
+   eggs
+   jobs
 
 You can use the `python-scrapinghub <https://github.com/scrapinghub/python-scrapinghub>`_ library to interface with these endpoints. To install with pip::
 
@@ -58,14 +59,15 @@ storage.scrapinghub.com
 -----------------------
 
 .. toctree::
+   :maxdepth: 2
 
-	activity
-	collections
-	frontier
-	items
-	jobq
-	logs
-	requests
+   activity
+   collections
+   frontier
+   items
+   jobq
+   logs
+   requests
 
 You can use the `python-hubstorage <https://github.com/scrapinghub/python-hubstorage>`_ library to interface with these endpoints. To install with pip::
 

--- a/api/requests.rst
+++ b/api/requests.rst
@@ -6,6 +6,8 @@ Requests API
 
 The requests API allows you to work with request and response data from your crawls.
 
+.. include:: client_library.rst
+
 Request object
 --------------
 
@@ -28,21 +30,30 @@ requests/:project_id/:spider_id/:job_id
 
 Retrieve or insert request data.
 
-Here is an example of reading data::
+Examples
+^^^^^^^^
+
+**Get the requests from a given job**
+
+HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/requests/53/34/7
     {"parent":0,"duration":12,"status":200,"method":"GET","rs":1024,"url":"http://scrapy.org/","time":1351521736957}
 
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
+
+    >>> reqs = hc.get_job('53/34/7').requests.list()
+
+
 .. note:: Pagination and meta parameters are supported, see :ref:`api-overview-pagination` and :ref:`api-overview-metapar`.
 
-Adding requests
-~~~~~~~~~~~~~~~
+**Adding requests**
 
 HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/requests/53/34/7 -X POST -T requests.jl
 
-Python::
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
 
 	>>> job = hc.get_job('53/34/7')
 	>>> job.requests.add('http://scrapy.org/', 200, GET, 1024, 0, 12, 1351521736957)
@@ -61,8 +72,17 @@ totals.input_bytes  The total size of all requests in bytes.
 totals.input_values The total number of requests.
 =================== ========================================
 
-GET example::
+Example
+^^^^^^^
+
+HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/requests/53/34/7/stats
     {"counts":{"url":21,"parent":19,"status":21,"method":21,"rs":21,"duration":21,"fp":21},"totals":{"input_bytes":2397,"input_values":21}}
 
+Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
+
+    >>> print hc.get_job('53/34/7').requests.stats()
+
+
+.. _`python-hubstorage`: http://github.com/scrapinghub/python-hubstorage


### PR DESCRIPTION
This PR adds `python-hubstorage` examples for:
* Frontier
* Items
* JobQ
* Requests