### PR TITLE
fix broken link to python-hubstorage

### DIFF
--- a/api/client_library.rst
+++ b/api/client_library.rst
@@ -1,6 +1,6 @@
 **Client Library**
 
-Most of the features provided by the API are also available through the python-hubstorage_ client library, as you can see below in :ref:`items-examples`. You have to authenticate yourself to create a ``HubstorageClient`` object to interact with hubstorage::
+Most of the features provided by the API are also available through the :ref:`python-hubstorage<api-overview-ep-storage>` client library, as you can see below in :ref:`items-examples`. You have to authenticate yourself to create a ``HubstorageClient`` object to interact with hubstorage::
 
     >>> from hubstorage import HubstorageClient
     >>> hc = HubstorageClient(auth=APIKEY)


### PR DESCRIPTION
It was not working in the jobs page.