### PR TITLE
Fix wrong method description for listing project eggs via API

### DIFF
--- a/api/eggs.rst
+++ b/api/eggs.rst
@@ -66,7 +66,7 @@ project   Project ID. Yes
 ====== =========================================== ====================
 Method Description                                 Supported parameters
 ====== =========================================== ====================
-POST   List Python eggs for the specified project. project
+GET    List Python eggs for the specified project. project
 ====== =========================================== ====================
 
 Example::


### PR DESCRIPTION
Example correctly uses GET