### PR TITLE
Fix frontier API endpoint

### DIFF
--- a/api/frontier.rst
+++ b/api/frontier.rst
@@ -180,8 +180,8 @@ Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
 
 Results are ordered lexicographically by fingerprint value.
 
-/hcf/:project_id/:frontier/list
--------------------------------
+/hcf/:project_id/list
+---------------------
 
 Lists the frontiers for a given project.
 


### PR DESCRIPTION
The correct endpoint to list the frontiers is **/hcf/:project_id/list**.
