### PR TITLE
Fixed: Incorrectly handling Crawlera sessions with Lua script on Splash

### DIFF
--- a/_static/crawlera-splash.lua
+++ b/_static/crawlera-splash.lua
@@ -13,7 +13,7 @@ function main(splash)
     end)
 
     splash:on_response_headers(function (response)
-        if type(response.headers[session_header]) ~= nil then
+        if response.headers[session_header] ~= nil then
             session_id = response.headers[session_header]
         end
     end)


### PR DESCRIPTION
In Lua `type(nil) == 'nil'`, not `nil`. It might cause issues (e.g. erasing existing Crawlera session and requesting a new one) in some specific cases.