### PR TITLE
Update docs with a link to the updated Python client

### DIFF
--- a/api/activity.rst
+++ b/api/activity.rst
@@ -10,7 +10,7 @@ clicking on **Activity** in the left sidebar, or programmatically through the
 API described below.
 
 activity/:project_id
----------------------
+--------------------
 
 Retrieve messages for a specified project. Results are returned in reverse order.
 
@@ -42,7 +42,7 @@ POST example::
 activity/projects
 -----------------
 
-Retrieve messages for multiple projects. 
+Retrieve messages for multiple projects.
 
 Results are returned in reverse order.
 

--- a/api/client_library.rst
+++ b/api/client_library.rst
@@ -1,6 +1,4 @@
-**Client Library**
+.. note::
 
-Most of the features provided by the API are also available through the :ref:`python-hubstorage<api-overview-ep-storage>` client library, as you can see below in :ref:`items-examples`. You have to authenticate yourself to create a ``HubstorageClient`` object to interact with hubstorage::
-
-    >>> from hubstorage import HubstorageClient
-    >>> hc = HubstorageClient(auth=APIKEY)
+    Most of the features provided by the API are also available through the
+    :ref:`python-scrapinghub<python-client>` client library.

--- a/api/collections.rst
+++ b/api/collections.rst
@@ -13,7 +13,7 @@ The *Collections API* allows storing arbitrary objects in named sets. For exampl
 
 Will post an object to the ``my_collection`` collection. You can submit multiple objects by separating them with newlines. The ``_key`` field is required and used to identify the item and should be unique.
 
-The ``/s/`` in the path represents the collection type. See below for more details. 
+The ``/s/`` in the path represents the collection type. See below for more details.
 
 Collection types
 ----------------
@@ -29,12 +29,6 @@ vs    versioned store       new_versioned_store        Up to 3 copies of each it
 vcs   versioned cache store new_versioned_cached_store Multiple copies are retained, and each one expires after a month
 ====  ===================== ========================== ================================================================
 
-When working with collections with :ref:`python-hubstorage<api-overview-ep-storage>`, you need to select the store. The method you use depends on the type. For example, to access a cached store, you need to use the ``new_cached_store`` method::
-
-    >>> collections = project.collections
-    >>> collections.new_cached_store('Pages')
-
-Using the wrong storage type will result in a ``KeyError`` when trying to retrieve an item.
 
 collections/:project_id/:type/:collection
 -----------------------------------------
@@ -70,8 +64,6 @@ GET examples::
     $ curl -u APIKEY: "https://storage.scrapinghub.com/collections/78/s/my_collection?startts=1402699941000&endts=1403039369570"
     {"value":"bar"}
 
-.. note:: When using :ref:`python-hubstorage <api-overview-ep-storage>`, you should use the method ``iter_json`` to iterate through items in order to filter them.
-
 Prefix filters, unlike other filters, use indexes and should be used when possible. You can use the ``prefixcount`` parameter to limit the number of values returned for each prefix.
 
 A common pattern is to download changes within a certain time period. You can use the ``startts`` and ``endts`` parameters to select records within a certain time window.
@@ -93,12 +85,6 @@ HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/collections/78/s/my_collection/foo
     {"value":"bar"}
-
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> store = project.collections.new_store('my_collection')
-    >>> store.get('foo')
-    {u'value': u'bar'}
 
 collections/:project_id/:type/:collection/:item/value
 -----------------------------------------------------

--- a/api/comments.rst
+++ b/api/comments.rst
@@ -66,7 +66,7 @@ Where ``comment`` is a comment object as defined above.
 
 
 comments/:project_id/stats
----------------------------
+--------------------------
 
 Retrieves the number of items with unarchived comments for each job of the project.
 

--- a/api/frontier.rst
+++ b/api/frontier.rst
@@ -75,13 +75,6 @@ HTTP::
         https://storage.scrapinghub.com/hcf/78/test/s/example.com
     {"newcount":1}
 
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> frontier = hc.get_project('78').frontier
-    >>> frontier.add('test', 'example.com', [{'fp': '/some/path.html'}])
-    >>> frontier.flush()
-    >>> frontier.newcount
-    1
 
 **Add requests with additional parameters**
 
@@ -94,15 +87,6 @@ HTTP::
     {"newcount":2}
 
 
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> frontier = hc.get_project('78').frontier
-    >>> frontier.add('test', 'example.com', [{'fp': '/'}, {'fp': 'page1.html', 'p': 1, 'qdata': {'depth': 1}}])
-    >>> frontier.flush()
-    >>> frontier.newcount
-    2
-
-
 DELETE example
 ^^^^^^^^^^^^^^
 
@@ -112,10 +96,6 @@ HTTP::
 
     $ curl -u API_KEY: -X DELETE https://storage.scrapinghub.com/hcf/78/test/s/example.com/
 
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> frontier = hc.get_project('78').frontier
-    >>> frontier.delete_slot('test', 'example.com')
 
 /hcf/:project_id/:frontier/s/:slot/q
 ------------------------------------
@@ -134,10 +114,6 @@ HTTP::
     {"id":"00013967d8af7b0001","requests":[["/",null]]}
     {"id":"01013967d8af7e0001","requests":[["page1.html",{"depth":1}]]}
 
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> frontier = hc.get_project('78').frontier
-    >>> reqs = frontier.read('test', 'example.com')
 
 /hcf/:project_id/:frontier/s/:slot/q/deleted
 --------------------------------------------
@@ -151,11 +127,6 @@ This can be achieved by posting the IDs of the completed batches::
     $ curl -u API_KEY: -d '"00013967d8af7b0001"' https://storage.scrapinghub.com/hcf/78/test/s/example.com/q/deleted
 
 You can specify the IDs as arrays or single values. As with the previous examples, multiple lines of input is accepted.
-
-You can do the same using the Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> frontier = hc.get_project('78').frontier
-    >>> frontier.delete('test', 'example.com', '00013967d8af7b0001')
 
 
 /hcf/:project_id/:frontier/s/:slot/f
@@ -171,11 +142,6 @@ HTTP::
     $ curl -u API_KEY: https://storage.scrapinghub.com/hcf/78/test/s/example.com/f
     {"fp":"/"}
     {"fp":"page1.html"}
-
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> frontier = hc.get_project('78').frontier
-    >>> fps = [req['requests'] for req in frontier.read('test', 'example.com')]
 
 
 Results are ordered lexicographically by fingerprint value.
@@ -207,6 +173,3 @@ HTTP::
 
     $ curl -u API_KEY: https://storage.scrapinghub.com/hcf/78/test/list
     ["example.com"]
-
-
-.. _`python-hubstorage`: http://github.com/scrapinghub/python-hubstorage

--- a/api/items.rst
+++ b/api/items.rst
@@ -24,7 +24,7 @@ _cached_page_id Cached page ID. Used to identify the scraped page in storage.
 =============== =======================================================================
 
 Scraped fields will be top level alongside the internal fields listed above.
- 
+
 items/:project_id[/:spider_id][/:job_id][/:item_no][/:field_name]
 -----------------------------------------------------------------
 
@@ -62,19 +62,12 @@ HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7
 
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> items = hc.get_job('53/34/7').items.list()
 
 **Retrive first item from a given job**
 
 HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7/0
-
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> item = hc.get_job('53/34/7').items.get(0)
 
 
 **Retrieve values from a single field**
@@ -83,10 +76,6 @@ HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7/fieldname
 
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> items_fieldname = [item['fieldname'] for item in hc.get_job('53/34/7').items.list()]
-
 
 **Retrieve all items from a given spider**
 
@@ -94,22 +83,12 @@ HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34
 
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> for job in hc.get_project(53).jobq.list(spider='spidername'):
-    >>>     for item in hc.get_job(job['key']).items.list():
-                print item
-
 
 **Retrieve all items from a given project**
 
 HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/
-
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> items = hc.get_project(53).items.list()
 
 
 **Get meta field from items**
@@ -122,10 +101,6 @@ HTTP::
     {"_key":"53/1/7/0"}
     {"_key":"53/1/7/1"}
     {"_key":"53/1/7/2"}
-
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> items = hc.get_job('53/1/7').items.iter_values(meta='_key', nodata='1')
 
 
 **Get items in a specific format**
@@ -194,10 +169,3 @@ HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7/stats
     {"counts":{"field1":9350,"field2":514},"totals":{"input_bytes":14390294,"input_values":10000}}
-
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> print hc.get_job('53/34/7').items.stats()
-
-
-.. _`python-hubstorage`: http://github.com/scrapinghub/python-hubstorage

--- a/api/jobq.rst
+++ b/api/jobq.rst
@@ -93,10 +93,6 @@ HTTP::
     {"key":"53/7/78","ts":1393972804722}
     {"key":"53/7/77","ts":1393972734215}
 
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> jobs = hc.get_project('53').jobq.list()
-
 
 **List jobs finished between two timestamps**
 
@@ -109,11 +105,6 @@ HTTP::
     {"key":"53/3/3","ts":1359774955437}
     {"key":"53/9/1","ts":1359774955431}
 
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> jobs = hc.get_project('53').jobq.list(startts=1359774955431, endts=1359774955440)
-
-
 
 **Retrieve jobs finished after some job**
 
@@ -124,10 +115,3 @@ Using HTTP::
     $ curl -u APIKEY: "https://storage.scrapinghub.com/jobq/53/list?stop=53/7/81"
     {"key":"53/7/83","ts":1403610146780}
     {"key":"53/7/82","ts":1397827910849}
-
-Using Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> jobs = hc.get_project('53').jobq.list(stop='53/7/81')
-
-
-.. _`python-hubstorage`: http://github.com/scrapinghub/python-hubstorage

--- a/api/jobs.rst
+++ b/api/jobs.rst
@@ -173,7 +173,7 @@ Examples::
 
 
     # Retrieve all jobs with the tag ``consumed``
-    $ curl -u APIKEY: "https://app.scrapinghub.com/api/jobs/list.json?project=123&lacks_tag=consumed" 
+    $ curl -u APIKEY: "https://app.scrapinghub.com/api/jobs/list.json?project=123&lacks_tag=consumed"
     {
       "status": "ok",
       "count": 3,
@@ -232,12 +232,6 @@ Examples::
       ]
     }
 
-Python::
-
-  >>> project = hc.get_project('123')
-  >>> jobs_metadata = project.jobq.list()
-  >>> [j['key'] for j in jobs_metadata]
-  ['1111111/1/3', '1111111/1/2', '1111111/1/1']
 
 jobs/update.json
 ----------------
@@ -263,10 +257,6 @@ Example::
 
   $ curl -u APIKEY: https://app.scrapinghub.com/api/jobs/update.json -d project=123 -d job=123/1/2 -d add_tag=consumed
 
-Python::
-
-  >>> job = hc.get_job('123/1/2')
-  >>> job.update(add_tag='consumed')
 
 jobs/delete.json
 ----------------
@@ -290,11 +280,6 @@ Example::
 
   $ curl -u APIKEY: https://app.scrapinghub.com/api/jobs/delete.json -d project=123 -d job=123/1/2 -d job=123/1/3
 
-Python::
-
-  >>> job = hc.get_job('123/1/2')
-  >>> job.delete()
-  1
 
 jobs/stop.json
 --------------
@@ -317,9 +302,3 @@ POST   Stop job(s). project, job
 Example::
 
   $ curl -u APIKEY: https://app.scrapinghub.com/api/jobs/stop.json -d project=123 -d job=123/1/1 -d job=123/1/2
-
-Python::
-
-  >>> job = hc.get_job('123/1/1')
-  >>> job.stop()
-  True

--- a/api/logs.rst
+++ b/api/logs.rst
@@ -43,15 +43,6 @@ HTTP::
     {"time":1444822757227,"level":20,"message":"Log opened."}
     {"time":1444822757229,"level":20,"message":"[scrapy.log] Scrapy 1.0.3.post6+g2d688cd started"}
 
-Python::
-
-	>>> job = hc.get_job('123/5/1')
-	>>> logs = job.logs.iter_values(count=10)
-	>>> for log in logs:
-	...     print(log)
-	...
-	{u'_key': u'123/5/1/0', u'message': u'Log opened.', u'level': 20, u'time': 1451863263099}
-	{u'_key': u'123/5/1/1', u'message': u'[scrapy.log] Scrapy 1.0.3.post6+g2d688cd started', u'level': 20, u'time': 1451863263103}
 
 Submitting logs
 ~~~~~~~~~~~~~~~

--- a/api/requests.rst
+++ b/api/requests.rst
@@ -41,10 +41,6 @@ HTTP::
     $ curl -u APIKEY: https://storage.scrapinghub.com/requests/53/34/7
     {"parent":0,"duration":12,"status":200,"method":"GET","rs":1024,"url":"http://scrapy.org/","time":1351521736957}
 
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> reqs = hc.get_job('53/34/7').requests.list()
-
 
 .. note:: Pagination and meta parameters are supported, see :ref:`api-overview-pagination` and :ref:`api-overview-metapar`.
 
@@ -53,11 +49,6 @@ Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
 HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/requests/53/34/7 -X POST -T requests.jl
-
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> job = hc.get_job('53/34/7')
-    >>> job.requests.add('http://scrapy.org/', 200, GET, 1024, 0, 12, 1351521736957)
 
 
 requests/:project_id/:spider_id/:job_id/stats
@@ -80,10 +71,3 @@ HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/requests/53/34/7/stats
     {"counts":{"url":21,"parent":19,"status":21,"method":21,"rs":21,"duration":21,"fp":21},"totals":{"input_bytes":2397,"input_values":21}}
-
-Python (:ref:`python-hubstorage<api-overview-ep-storage>`)::
-
-    >>> print hc.get_job('53/34/7').requests.stats()
-
-
-.. _`python-hubstorage`: http://github.com/scrapinghub/python-hubstorage

--- a/scrapy-cloud.rst
+++ b/scrapy-cloud.rst
@@ -6,7 +6,7 @@ Scrapy Cloud API
 
 .. note:: Check also the `Help Center`_ for general guides and articles.
 
-Scrapy Cloud API provides an interface for interacting with your spiders, jobs and scraped data.
+Scrapy Cloud provides an HTTP API for interacting with your spiders, jobs and scraped data.
 
 Getting started
 ===============
@@ -53,10 +53,6 @@ app.scrapinghub.com
    api/jobs
    api/comments
 
-You can use the `python-scrapinghub <https://github.com/scrapinghub/python-scrapinghub>`_ library to interface with these endpoints. To install with pip::
-
-    $ pip install scrapinghub
-
 .. _api-overview-ep-storage:
 
 storage.scrapinghub.com
@@ -73,11 +69,16 @@ storage.scrapinghub.com
    api/collections
    api/frontier
 
-You can use the `python-hubstorage <https://github.com/scrapinghub/python-hubstorage>`_ library to interface with these endpoints. To install with pip::
+.. _python-client:
 
-    $ pip install hubstorage
+Python client
+-------------
 
-.. _api-overview-pagination:
+You can use the `python-scrapinghub`_ library to interact with Scrapy Cloud API.
+Check the `documentation`__ for installation instructions and usage examples.
+
+.. _python-scrapinghub: https://github.com/scrapinghub/python-scrapinghub
+__ https://python-scrapinghub.readthedocs.io/
 
 Pagination
 ==========


### PR DESCRIPTION
- Remove references to deprecated python-hubstorage.
- Update python-scrapinghub description.
- Remove python examples from this site because python-scrapinghub
  now provides a very comprehensive documentation on Read The Docs.

Fixes #156