### PR TITLE
changing Python-Requests sample

### DIFF
--- a/_static/crawlera-python-requests-httpproxyauth.py
+++ b/_static/crawlera-python-requests-httpproxyauth.py
@@ -4,7 +4,8 @@ url = "https://twitter.com"
 proxy_host = "proxy.crawlera.com"
 proxy_port = "8010"
 proxy_auth = "<APIKEY>:"
-proxies = {"https": "https://{}@{}:{}/".format(proxy_auth, proxy_host, proxy_port)}
+proxies = {"https": "https://{}@{}:{}/".format(proxy_auth, proxy_host, proxy_port),
+           "http": "http://{}@{}:{}/".format(proxy_auth, proxy_host, proxy_port)}
 
 r = requests.get(url, proxies=proxies, verify='/path/to/crawlera-ca.crt')
 

--- a/_static/crawlera-python-requests-httpproxyauth.py
+++ b/_static/crawlera-python-requests-httpproxyauth.py
@@ -1,14 +1,12 @@
 import requests
-from requests.auth import HTTPProxyAuth
 
 url = "https://twitter.com"
 proxy_host = "proxy.crawlera.com"
 proxy_port = "8010"
-proxy_auth = HTTPProxyAuth("<API KEY>", "")
-proxies = {"https": "https://{}:{}/".format(proxy_host, proxy_port)}
+proxy_auth = "<APIKEY>:"
+proxies = {"https": "https://{}@{}:{}/".format(proxy_auth, proxy_host, proxy_port)}
 
-r = requests.get(url, proxies=proxies, auth=proxy_auth,
-                 verify='/path/to/crawlera-ca.crt')
+r = requests.get(url, proxies=proxies, verify='/path/to/crawlera-ca.crt')
 
 print("""
 Requesting [{}]


### PR DESCRIPTION
Based on discussion:
https://scrapinghub.slack.com/archives/C03R253C9/p1491399012184415

HTTPProxyAuth does not send credentials when following a redirect (301, 302)