### PR TITLE
Improve documentation about pagination usage

### DIFF
--- a/api/items.rst
+++ b/api/items.rst
@@ -112,7 +112,7 @@ HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7?count=10&startafter=53/34/7/19
 
-**[Pagination] Retrieve a few items from a given job by its IDs**
+**[Pagination] Retrieve a few items from a given job by their IDs**
 
 HTTP::
 

--- a/api/items.rst
+++ b/api/items.rst
@@ -53,7 +53,7 @@ GET    Retrieve items for a given project, spider, or job. format, meta, nodata
 POST   Insert items for a given job                        N/A
 ====== =================================================== ====================
 
-.. note:: Please always use pagination parameters ``start`` and ``count`` to limit amount of items in response to prevent timeouts and different performance issues. See pagination examples below for more details.
+.. note:: Please always use pagination parameters (``start``, ``startafter`` and ``count``) to limit amount of items in response to prevent timeouts and different performance issues. See pagination examples below for more details.
 
 .. _items-examples:
 
@@ -105,6 +105,12 @@ HTTP::
 HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7?count=10&start=53/34/7/20
+
+**[Pagination] Retrieve N items from a given job starting from the item following to the given one**
+
+HTTP::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7?count=10&startafter=53/34/7/19
 
 **[Pagination] Retrieve a few items from a given job by its IDs**
 

--- a/api/items.rst
+++ b/api/items.rst
@@ -38,6 +38,8 @@ meta      Meta keys to show.                                                   N
 nodata    If set, no data will be returned other than specified ``meta`` keys. No
 ========= ==================================================================== ========
 
+.. note:: Pagination and meta parameters are supported, see :ref:`api-overview-pagination` and :ref:`api-overview-metapar`.
+
 ============= ==========================================================
 Header        Description
 ============= ==========================================================
@@ -50,6 +52,8 @@ Method Description                                         Supported parameters
 GET    Retrieve items for a given project, spider, or job. format, meta, nodata
 POST   Insert items for a given job                        N/A
 ====== =================================================== ====================
+
+.. note:: Please always use pagination parameters ``start`` and ``count`` to limit amount of items in response to prevent timeouts and different performance issues. See pagination examples below for more details.
 
 .. _items-examples:
 
@@ -90,6 +94,24 @@ HTTP::
 
     $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/
 
+**[Pagination] Retrieve first N items from a given job**
+
+HTTP::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7?count=10
+
+**[Pagination] Retrieve N items from a given job starting from the given item**
+
+HTTP::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7?count=10&start=53/34/7/20
+
+**[Pagination] Retrieve a few items from a given job by its IDs**
+
+HTTP::
+
+    $ curl -u APIKEY: https://storage.scrapinghub.com/items/53/34/7?index=5&index=6
+
 
 **Get meta field from items**
 
@@ -101,7 +123,6 @@ HTTP::
     {"_key":"53/1/7/0"}
     {"_key":"53/1/7/1"}
     {"_key":"53/1/7/2"}
-
 
 **Get items in a specific format**
 

--- a/api/logs.rst
+++ b/api/logs.rst
@@ -44,6 +44,8 @@ Parameter Description                                            Required
 format    Results format. See :ref:`api-overview-resultformats`. No
 ========= ====================================================== ========
 
+.. note:: Pagination and meta parameters are supported, see :ref:`api-overview-pagination` and :ref:`api-overview-metapar`.
+
 ====== ============== ====================
 Method Description    Supported parameters
 ====== ============== ====================

--- a/api/requests.rst
+++ b/api/requests.rst
@@ -28,10 +28,26 @@ fp       Request fingerprint.                            No
 
 .. note:: Seed requests from start URLs will have no parent field.
 
+
+requests/:project_id[/:spider_id][/:job_id][/:request_no]
+-----------------------------------------------------------------
+
+Retrieve or insert request data for a project, spider or job, where ``request_no`` is the index of the request.
+
+========= ==================================================================== ========
+Parameter Description                                                          Required
+========= ==================================================================== ========
+format    Results format. See :ref:`api-overview-resultformats`.               No
+meta      Meta keys to show.                                                   No
+nodata    If set, no data will be returned other than specified ``meta`` keys. No
+========= ==================================================================== ========
+
+.. note:: Pagination and meta parameters are supported, see :ref:`api-overview-pagination` and :ref:`api-overview-metapar`.
+
+
 requests/:project_id/:spider_id/:job_id
 ---------------------------------------
 
-Retrieve or insert request data.
 
 Examples
 ^^^^^^^^
@@ -43,8 +59,6 @@ HTTP::
     $ curl -u APIKEY: https://storage.scrapinghub.com/requests/53/34/7
     {"parent":0,"duration":12,"status":200,"method":"GET","rs":1024,"url":"http://scrapy.org/","time":1351521736957}
 
-
-.. note:: Pagination and meta parameters are supported, see :ref:`api-overview-pagination` and :ref:`api-overview-metapar`.
 
 **Adding requests**
 

--- a/scrapy-cloud.rst
+++ b/scrapy-cloud.rst
@@ -87,15 +87,16 @@ Pagination
 
 You can paginate the results for the majority of the APIs using a number of parameters.
 
-========= =================================================================
-Parameter Description
-========= =================================================================
-start     Skip results before the given one. See a note about format below.
-count     Number of results per page.
-index     Offset to retrieve specific records. Multiple values supported.
-========= =================================================================
+========== ==================================================================
+Parameter  Description
+========== ==================================================================
+start      Skip results before the given one. See a note about format below.
+startafter Return results after the given one. See a note about format below.
+count      Number of results per page.
+index      Offset to retrieve specific records. Multiple values supported.
+========== ==================================================================
 
-.. note:: While ``index`` parameter is just a short ``<entity_id>`` (ex: ``index=4``), ``start`` parameter should have the full form ``<project_id>/<spider_id>/<job_id>/<entity_id>`` (ex: ``start=1/2/3/4``).
+.. note:: While ``index`` parameter is just a short ``<entity_id>`` (ex: ``index=4``), ``start`` and ``startafter`` parameters should have the full form ``<project_id>/<spider_id>/<job_id>/<entity_id>`` (ex: ``start=1/2/3/4``, ``startafter=1/2/3/3``).
 
 .. _api-overview-resultformats:
 

--- a/scrapy-cloud.rst
+++ b/scrapy-cloud.rst
@@ -87,13 +87,15 @@ Pagination
 
 You can paginate the results for the majority of the APIs using a number of parameters.
 
-========= ====================================================================
+========= =================================================================
 Parameter Description
-========= ====================================================================
-start     The offset from which to start retrieving results.
+========= =================================================================
+start     Skip results before the given one. See a note about format below.
 count     Number of results per page.
-index     Can be used to retrieve specific records. Multiple values supported.
-========= ====================================================================
+index     Offset to retrieve specific records. Multiple values supported.
+========= =================================================================
+
+.. note:: While ``index`` parameter is just a short ``<entity_id>`` (ex: ``index=4``), ``start`` parameter should have the full form ``<project_id>/<spider_id>/<job_id>/<entity_id>`` (ex: ``start=1/2/3/4``).
 
 .. _api-overview-resultformats:
 


### PR DESCRIPTION
There was a question about correct pagination usage, and looks like current documentation could be improved: I was able to find pagination logic details [here](https://doc.scrapinghub.com/scrapy-cloud.html#pagination) and a corresponding link in the left menu, but users can still skip it accidentally when checking info about parameters of specific items/requests/logs endpoints. 

The PR tries to improve it for the endpoints and adds some additional examples, review please.