### PR TITLE
editing sessions limit section

### DIFF
--- a/crawlera.rst
+++ b/crawlera.rst
@@ -49,8 +49,8 @@ bad_header             540            Bad header value for *<some_header>*
 
 .. _sessions-request-limits:
 
-Sessions and Request Limits
-===========================
+Sessions
+========
 
 Sessions
 --------
@@ -101,10 +101,10 @@ Issue the endpoint :ref:`/sessions/SESSION_ID` with the ``DELETE`` method in ord
 
     curl -u <API key>: proxy.crawlera.com:8010/sessions/1836172 -X DELETE
 
-Request Limits
---------------
+Session Request Limits
+----------------------
 
-Crawlera’s default request limit is 5 requests per second (rps) for each website. There is a default delay of 12 seconds between each request and a default delay of 1 second between requests through the same slave. These delays can differ for more popular domains. If the requests per second limit is exceeded, further requests will be delayed for up to 15 minutes. Each request made after exceeding the limit will increase the request delay. If the request delay reaches the soft limit (120 seconds), then each subsequent request will contain :ref:`x-crawlera-next-request-in` header with the calculated delay as the value.
+There is a default delay of 12 seconds between each request using the same IP. These delays can differ for more popular domains. If the requests per second limit is exceeded, further requests will be delayed for up to 15 minutes. Each request made after exceeding the limit will increase the request delay. If the request delay reaches the soft limit (120 seconds), then each subsequent request will contain :ref:`x-crawlera-next-request-in` header with the calculated delay as the value.
 
 
 Request Headers


### PR DESCRIPTION
This poses more questions than what it actually answers.
Correcting also inverted value, the default delay between the same IP was 12 not 1.
And making this section more relevant to Session users.