### PR TITLE
fixed "Title underline too short" warning in crawlera-stats.rst

### DIFF
--- a/crawlera-stats.rst
+++ b/crawlera-stats.rst
@@ -17,7 +17,7 @@ API endpoints
 root url: "crawlera-stats.scrapinghub.com"
 
 /stats
------
+------
 
 Crawlera usage stats.
 


### PR DESCRIPTION
make html shows a warning without it:

> WARNING: /Users/kmike/svn/doc.scrapinghub.com/crawlera-stats.rst:20: (WARNING/2) Title underline too short.